### PR TITLE
Fix required VTK components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 # vtk
 find_package(VTK REQUIRED COMPONENTS vtkIOGeometry NO_MODULE)
 if (${VTK_VERSION} VERSION_GREATER "9")
-   find_package(VTK REQUIRED COMPONENTS CommonCore RenderingCore GUISupportQt RenderingLOD NO_MODULE)
+   find_package(VTK REQUIRED COMPONENTS CommonCore RenderingCore GUISupportQt RenderingLOD FiltersParallel IOGeometry IOImage IOPLY IOXML InteractionStyle RenderingAnnotation RenderingFreeType NO_MODULE)
 else()
     find_package(VTK REQUIRED)
 endif()


### PR DESCRIPTION
Would not build with VTK 9. More components needed to be included in `find_package` in order for all symbols to be defined during compilation.