### PR TITLE
Fix CMake 4 / macOS Homebrew Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,10 @@ ENDIF()
 
 PROJECT( QCSXCAD CXX)
 
-cmake_minimum_required(VERSION 2.8)
+# In CMake 4, 3.10 is deprecated and 3.5 has been removed.
+# use 3.0...3.10 so all of these versions are acceptable as min. version.
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+cmake_minimum_required(VERSION 3.0...3.10)
 
 # https://cmake.org/cmake/help/v3.0/policy/CMP0020.html
 if(POLICY CMP0020)


### PR DESCRIPTION
## CMakeLists.txt: use 3.0...3.10 as minimum version.

In CMake 4, 3.10 is deprecated and 3.5 has been removed. Use 3.0...3.10 so all of these versions are acceptable as minimum version. CMake 2.8 is dropped since openEMS has already dropped it, so there's no point of maintaining its support. Furthermore, CMake 2.8 is ancient that it's no longer found in the documentation today.

Currently, only macOS's Homebrew has rolled it out, but it's expected to arrive to more systems in the upcoming years. So this commit prepares the project for the upcoming CMake 4.0.